### PR TITLE
have JupyterOperator use jupytext, can run Rmd

### DIFF
--- a/airflow/dags/maiden_dag/jupytext_example.Rmd
+++ b/airflow/dags/maiden_dag/jupytext_example.Rmd
@@ -1,0 +1,23 @@
+---
+operator: JupyterOperator
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .Rmd
+      format_name: rmarkdown
+      format_version: '1.2'
+      jupytext_version: 1.3.3
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# Demo jupyter notebook
+
+This notebook is run using jupyter. For the sake of this example, changes here will also show up in `jupytext_example2.Rmd`.
+
+```{python}
+for ii in range(3):
+    print("whoa!")
+```

--- a/airflow/dags/utils/operators/JupyterOperator.py
+++ b/airflow/dags/utils/operators/JupyterOperator.py
@@ -34,7 +34,7 @@ class JupyterOperator(SSHOperator):
         self.ui_color = job_colors["ipynb"]
 
         # The volume is shared at the same location with the pythonserver container
-        self.command = '(jupyter nbconvert --to script --execute --stdout %s | python)' % (self.ipynb_file, )
+        self.command = '(jupytext --to py --output - %s | python)' % (self.ipynb_file, )
 
         super(JupyterOperator, self).__init__(
             command = self.command,

--- a/pythonserver/Dockerfile
+++ b/pythonserver/Dockerfile
@@ -15,5 +15,5 @@ RUN sudo echo 'AllowUsers pythonuser' >> /etc/ssh/sshd_config
 RUN sudo echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
 
 # Install libraries
-RUN pip install jupyter
+RUN pip install jupyter jupytext
 RUN pip install pandas


### PR DESCRIPTION
This PR allows the execution of Rmds that are python code. These files are commonly created using jupytext, as it supports opening / roundtripping these files as jupyter notebooks.